### PR TITLE
Add autostart for Tap Ho on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,5 +8,22 @@
 </head>
 <body class="home-page">
   <button class="enter-btn" onclick="window.location.href='home.html'">Enter</button>
+
+  <!-- Hidden SoundCloud player for Tap Ho -->
+  <iframe id="sc-player" style="display:none" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/wobbob/tap-ho&auto_play=true"></iframe>
+
+  <script src="https://w.soundcloud.com/player/api.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var iframe = document.getElementById('sc-player');
+      if (iframe) {
+        var widget = SC.Widget(iframe);
+        widget.bind(SC.Widget.Events.READY, function () {
+          widget.seekTo(520);
+          widget.play();
+        });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- auto-play the SoundCloud track "Tap Ho" when index loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849eb3ccff0832589a92ad674323072

## Summary by Sourcery

New Features:
- Autoplay the "Tap Ho" track through a hidden SoundCloud widget on the landing page.