### PR TITLE
Improve deck visuals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -308,13 +308,13 @@ body {
 
 /* Individual deck styling */
 .cdj-deck {
-  width: 340px;
-  border-radius: 20px;
-  background: radial-gradient(circle at center, #111 0%, #000 80%);
-  box-shadow: 0 0 30px #ff0, inset 0 0 10px #333;
+  width: 380px;
+  border-radius: 10px;
+  background: #111;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6), inset 0 0 15px #000;
   padding: 20px;
   position: relative;
-  border: 3px solid #ff69b4;
+  border: 2px solid #444;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -323,12 +323,24 @@ body {
 /* Platter */
 .platter {
   position: relative;
-  width: 300px;
-  height: 300px;
+  width: 320px;
+  height: 320px;
   border-radius: 50%;
   background: radial-gradient(circle at center, #333 0%, #000 100%);
-  box-shadow: inset 0 0 10px #000;
+  box-shadow: inset 0 0 15px #000;
   margin-bottom: 20px;
+}
+
+.platter::after {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: -6px;
+  right: -6px;
+  bottom: -6px;
+  border-radius: 50%;
+  border: 4px dotted #666;
+  opacity: 0.4;
 }
 
 /* Record */
@@ -336,21 +348,24 @@ body {
   position: absolute;
   top: 25px;
   left: 25px;
-  width: 250px;
-  height: 250px;
+  width: 270px;
+  height: 270px;
   border-radius: 50%;
   background: radial-gradient(circle at center, #111 0%, #222 100%);
   box-shadow: inset 0 0 5px #000;
+}
+
+.record.spinning {
   animation: spin 3s linear infinite;
 }
 
 /* Label */
 .label {
   position: absolute;
-  top: 90px;
-  left: 90px;
-  width: 70px;
-  height: 70px;
+  top: 100px;
+  left: 100px;
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
   background: #ff0;
   box-shadow: 0 0 5px #ff0;
@@ -359,10 +374,10 @@ body {
 /* Spindle */
 .spindle {
   position: absolute;
-  top: 120px;
-  left: 120px;
-  width: 10px;
-  height: 10px;
+  top: 135px;
+  left: 135px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: #ccc;
   box-shadow: 0 0 2px #999;
@@ -371,19 +386,23 @@ body {
 /* Tonearm */
 .tonearm {
   position: absolute;
-  top: 60px;
-  left: 220px;
-  width: 80px;
-  height: 10px;
-  background: #666;
-  transform: rotate(45deg);
+  top: 70px;
+  left: 230px;
+  width: 120px;
+  height: 6px;
+  background: linear-gradient(#eee, #aaa);
+  border-radius: 3px;
+  transform: rotate(40deg);
   transform-origin: left center;
+  box-shadow: 0 0 4px #000;
 }
 
 /* Controls */
 .controls {
   width: 100%;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .start-stop {
@@ -393,12 +412,14 @@ body {
   border-radius: 5px;
   color: #fff;
   cursor: pointer;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
+  font-weight: bold;
 }
 
 .pitch-slider {
-  width: 80%;
-  margin-bottom: 10px;
+  width: 180px;
+  margin: 0 20px;
+  transform: rotate(-90deg);
 }
 
 /* Embed wrapper */

--- a/home.html
+++ b/home.html
@@ -79,5 +79,7 @@
       </div>
     </footer>
 
+    <script src="js/deck.js"></script>
+
 </body>
 </html>

--- a/js/deck.js
+++ b/js/deck.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const decks = document.querySelectorAll('.cdj-deck');
+  decks.forEach(deck => {
+    const button = deck.querySelector('.start-stop');
+    const record = deck.querySelector('.record');
+    if (button && record) {
+      button.addEventListener('click', () => {
+        record.classList.toggle('spinning');
+      });
+    }
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "wobbob.pro",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- refine cdj decks to better match classic turntables
- enable start-stop behavior using JS
- add minimal package.json for npm compatibility

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849f9a03e608325ad6c3d7e20b4f190